### PR TITLE
Remove ModalLogout from HeaderHamburgerMenu and instead emit to header

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -71,8 +71,9 @@
         <HeaderHamburgerMenu
             :is-open="state.isHamburgerOpen"
             @toggle="toggle"
+            @logout="state.isLogoutOpen = true"
         />
-        <ModalLogOut v-model="state.isLogoutOpen" />
+        <ModalLogOut v-if="isInterface" v-model="state.isLogoutOpen" />
     </div>
 </template>
 

--- a/src/components/HeaderHamburgerMenu.vue
+++ b/src/components/HeaderHamburgerMenu.vue
@@ -45,7 +45,6 @@
                 @click="handleLogout"
             />
         </div>
-        <ModalLogOut v-model="state.isLogoutOpen" />
     </nav>
 </template>
 
@@ -75,7 +74,6 @@ export default createComponent({
         MaterialDesignIcon,
         BalanceCard,
         NetworkCard,
-        ModalLogOut,
         Button
     },
     props: {
@@ -128,7 +126,7 @@ export default createComponent({
 
         function handleLogout(): void {
             context.emit("toggle", !props.isOpen);
-            state.isLogoutOpen = true;
+            context.emit("logout");
         }
 
         return {

--- a/src/components/HeaderHamburgerMenu.vue
+++ b/src/components/HeaderHamburgerMenu.vue
@@ -54,7 +54,6 @@ import { mdiChevronRight } from "@mdi/js";
 import BalanceCard from "./BalanceCard.vue";
 import NetworkCard from "./NetworkCard.vue";
 import store from "../store";
-import ModalLogOut from "./ModalLogOut.vue";
 import Button from "../components/Button.vue";
 
 import {

--- a/tests/unit/components/Header.spec.ts
+++ b/tests/unit/components/Header.spec.ts
@@ -60,41 +60,8 @@ describe("Header.vue", (): void => {
                 <div class="logout-container">
                   <!---->
                 </div>
-                <div role="dialog" aria-modal="true" class="modal-background">
-                  <div class="modal">
-                    <!---->
-                    <div class="main">
-                      <div class="content-container">
-                        <div class="modal-forgot-to-logout"><span>Log Out</span>
-                          <p>
-                            Are you sure?
-                          </p>
-                          <div class="button-group">
-                            <!----> <button type="submit" class="button-logout danger center-button"><span>Log Out</span>
-                              <!----></button></div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
               </nav>
-              <div role="dialog" aria-modal="true" class="modal-background">
-                <div class="modal">
-                  <!---->
-                  <div class="main">
-                    <div class="content-container">
-                      <div class="modal-forgot-to-logout"><span>Log Out</span>
-                        <p>
-                          Are you sure?
-                        </p>
-                        <div class="button-group">
-                          <!----> <button type="submit" class="button-logout danger center-button"><span>Log Out</span>
-                            <!----></button></div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
+              <!---->
             </div>
         `);
     });

--- a/tests/unit/components/HeaderHamburgerMenu.spec.ts
+++ b/tests/unit/components/HeaderHamburgerMenu.spec.ts
@@ -40,23 +40,6 @@ describe("HeaderHamburgerMenu.vue", (): void => {
               <div class="logout-container">
                 <!---->
               </div>
-              <div role="dialog" aria-modal="true" class="modal-background">
-                <div class="modal">
-                  <!---->
-                  <div class="main">
-                    <div class="content-container">
-                      <div class="modal-forgot-to-logout"><span>Log Out</span>
-                        <p>
-                          Are you sure?
-                        </p>
-                        <div class="button-group">
-                          <!----> <button type="submit" class="button-logout danger center-button"><span>Log Out</span>
-                            <!----></button></div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
             </nav>
         `);
     });


### PR DESCRIPTION
Found this while fixing e2e tests - I had added an unnecessary ModalLogout and was not hiding them when outside of interface, causing Home to load 3 separate ModalLogouts