### PR TITLE
Remove white blip

### DIFF
--- a/src/electron/background.ts
+++ b/src/electron/background.ts
@@ -20,6 +20,14 @@ function createWindow(): void {
         height: 768,
         webPreferences: {
             nodeIntegration: true
+        },
+        show: false
+    });
+
+    // wait to show the window until the page is actually loaded
+    win.once("ready-to-show", () => {
+        if(win != null) {
+            win.show();
         }
     });
 


### PR DESCRIPTION
closes #67 

Have to wait for the `ready-to-show` event before rendering the window to prevent the blip.