### PR TITLE
Remove SDK type imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,16 +9,6 @@ module.exports = {
         // v-html is used for rich text formatting for i18n
         "vue/no-v-html": "off",
         // This rule has many false positives in this codebase
-        "require-atomic-updates": "off",
-
-        // this lint only works on static imports
-        // it is used to enforce dynamically importing the Hedera sdk
-        "no-restricted-imports": [
-            "error",
-            {
-                name: "@hashgraph/sdk",
-                message: "The hashgraph sdk must be imported dynamically"
-            }
-        ]
+        "require-atomic-updates": "off"
     }
 };

--- a/src/components/AccountCard.vue
+++ b/src/components/AccountCard.vue
@@ -68,10 +68,9 @@ import ModalViewAccountId from "../components/ModalViewAccountId.vue";
 import ExportKeystoreButton from "./ExportKeystoreButton.vue";
 import ModalViewKeys from "./ModalViewKeys.vue";
 import store from "../store";
+import { Ed25519PrivateKey, Ed25519PublicKey, PublicKey } from "@hashgraph/sdk";
 
-async function getPrivateKey(): Promise<
-    import("@hashgraph/sdk").Ed25519PrivateKey | null
-> {
+async function getPrivateKey(): Promise<Ed25519PrivateKey | null> {
     if (store.state.wallet.session !== null) {
         if (store.state.wallet.session.wallet.hasPrivateKey()) {
             return store.state.wallet.session.wallet.getPrivateKey();
@@ -81,9 +80,7 @@ async function getPrivateKey(): Promise<
     return null;
 }
 
-async function getPublicKey(): Promise<
-    import("@hashgraph/sdk").PublicKey | null
-> {
+async function getPublicKey(): Promise<PublicKey | null> {
     if (store.state.wallet.session !== null) {
         return store.state.wallet.session.wallet.getPublicKey();
     }
@@ -115,28 +112,17 @@ export default createComponent({
         const state = reactive({
             viewAccountQrCodeIsOpen: false,
             viewKeysIsOpen: false,
-            publicKey: null as import("@hashgraph/sdk").PublicKey | null,
-            privateKey: null as
-                | import("@hashgraph/sdk").Ed25519PrivateKey
-                | null
+            publicKey: null as PublicKey | null,
+            privateKey: null as Ed25519PrivateKey | null
+        });
+
+        watch(getPublicKey, async (result: Promise<PublicKey | null>) => {
+            state.publicKey = await result;
         });
 
         watch(
-            getPublicKey,
-            async (
-                result: Promise<import("@hashgraph/sdk").PublicKey | null>
-            ) => {
-                state.publicKey = await result;
-            }
-        );
-
-        watch(
             getPrivateKey,
-            async (
-                result: Promise<
-                    import("@hashgraph/sdk").Ed25519PrivateKey | null
-                >
-            ) => {
+            async (result: Promise<Ed25519PrivateKey | null>) => {
                 state.privateKey = await result;
             }
         );
@@ -161,9 +147,7 @@ export default createComponent({
 
         const publicKeyString = computed(() => {
             if (state.publicKey !== null) {
-                return (state.publicKey as import("@hashgraph/sdk").Ed25519PublicKey).toString(
-                    true
-                );
+                return (state.publicKey as Ed25519PublicKey).toString(true);
             }
 
             return "";

--- a/src/components/ModalCreateByPhrase.vue
+++ b/src/components/ModalCreateByPhrase.vue
@@ -113,6 +113,7 @@ import {
     SetupContext
 } from "@vue/composition-api";
 import { formatRich } from "../formatter";
+import { Ed25519PrivateKey, MnemonicResult } from "@hashgraph/sdk";
 
 interface Props {
     isOpen: boolean;
@@ -145,7 +146,7 @@ export default createComponent({
         const state = reactive({
             isBusy: false,
             passwordValue: "",
-            result: null as import("@hashgraph/sdk").MnemonicResult | null,
+            result: null as MnemonicResult | null,
             printModalIsOpen: false,
             verifyPhraseIsOpen: false
         });
@@ -187,7 +188,7 @@ export default createComponent({
             state.verifyPhraseIsOpen = false;
 
             // `.derive(0)` to generate the same key as the default account of the mobile wallet
-            const key: import("@hashgraph/sdk").Ed25519PrivateKey = (await state.result.generateKey()).derive(
+            const key: Ed25519PrivateKey = (await state.result.generateKey()).derive(
                 0
             );
 

--- a/src/components/ModalEnterAccountId.vue
+++ b/src/components/ModalEnterAccountId.vue
@@ -69,6 +69,7 @@ import { Id } from "../store/modules/wallet";
 import Notice from "../components/Notice.vue";
 import { mdiHelpCircleOutline } from "@mdi/js";
 import ReadOnlyInput from "./ReadOnlyInput.vue";
+import { Ed25519PublicKey } from "@hashgraph/sdk";
 
 export interface State {
     failed: string | null;
@@ -77,7 +78,7 @@ export interface State {
     isBusy: boolean;
     account: Id | null;
     valid: boolean;
-    publicKey: import("@hashgraph/sdk").Ed25519PublicKey | null;
+    publicKey: Ed25519PublicKey | null;
 }
 
 export interface Props {

--- a/src/components/ModalRequestToCreateAccount.vue
+++ b/src/components/ModalRequestToCreateAccount.vue
@@ -70,10 +70,11 @@ import { writeToClipboard } from "../clipboard";
 import ReadOnlyInput from "../components/ReadOnlyInput.vue";
 import { ALERT } from "../store/actions";
 import store from "../store";
+import { Ed25519PublicKey } from "@hashgraph/sdk";
 
 interface Props {
     isOpen: boolean;
-    publicKey: import("@hashgraph/sdk").Ed25519PublicKey;
+    publicKey: Ed25519PublicKey;
     event: string;
 }
 
@@ -91,9 +92,7 @@ export default createComponent({
     },
     props: {
         isOpen: (Boolean as unknown) as PropType<boolean>,
-        publicKey: (Object as unknown) as PropType<
-            import("@hashgraph/sdk").Ed25519PublicKey
-        >,
+        publicKey: (Object as unknown) as PropType<Ed25519PublicKey>,
         event: (String as unknown) as PropType<string>
     },
     setup(props: Props, context: SetupContext) {

--- a/src/store/modules/errors.ts
+++ b/src/store/modules/errors.ts
@@ -5,6 +5,7 @@ import { StatusCodes } from "@ledgerhq/hw-transport";
 import i18n from "../../../src/i18n";
 import { ActionContext } from "vuex";
 import { RootState } from "..";
+import {HederaError} from "@hashgraph/sdk";
 
 export interface State {
     errors: (Error | string)[];
@@ -25,13 +26,13 @@ export interface LedgerErrorTuple {
 }
 
 export interface HederaErrorPayload {
-    error: import("@hashgraph/sdk").HederaError;
+    error: HederaError;
     showAlert: boolean;
 }
 
 export interface HederaErrorTuple {
     message: string;
-    error: import("@hashgraph/sdk").HederaError;
+    error: HederaError;
 }
 
 export default {

--- a/src/store/modules/wallet.ts
+++ b/src/store/modules/wallet.ts
@@ -43,6 +43,7 @@ import { State as ModalAccessByPrivateKeyState } from "../components/ModalAccess
 import { State as ModalEnterAccountIdState } from "../components/ModalEnterAccountId";
 import BigNumber from "bignumber.js";
 import Wallet from "../../wallets/Wallet";
+import {Client, Ed25519PrivateKey, Ed25519PublicKey} from "@hashgraph/sdk";
 
 const SET_BALANCE = "wallet#set_balance";
 const SET_EXCHANGE_RATE = "wallet#set_exchange_rate";
@@ -78,7 +79,7 @@ export interface Id {
 export interface Session {
     account: Id;
     wallet: Wallet;
-    client: import("@hashgraph/sdk").Client;
+    client: Client;
 }
 
 export interface State {
@@ -97,8 +98,8 @@ type ModalRequestToCreateAccountState = ModalIsOpen;
 
 export interface AccountDTO {
     wallet: Wallet | null;
-    privateKey: import("@hashgraph/sdk").Ed25519PrivateKey | null;
-    publicKey: import("@hashgraph/sdk").Ed25519PublicKey | null;
+    privateKey: Ed25519PrivateKey | null;
+    publicKey: Ed25519PublicKey | null;
     keyFile: Uint8Array | null;
 }
 

--- a/src/views/AccessMyAccount.vue
+++ b/src/views/AccessMyAccount.vue
@@ -96,6 +96,13 @@ import SoftwareWallet from "../wallets/software/SoftwareWallet";
 import settings from "../settings";
 import { HederaErrorTuple, LedgerErrorTuple } from "src/store/modules/errors";
 import { LoginMethod } from "../wallets/Wallet";
+import {
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+    Operator,
+    Signer,
+    Client
+} from "@hashgraph/sdk";
 
 interface State {
     loginMethod: LoginMethod | null;
@@ -163,9 +170,7 @@ export default createComponent({
 
         const file = ref<HTMLInputElement | null>(null);
 
-        function setPrivateKey(
-            newPrivateKey: import("@hashgraph/sdk").Ed25519PrivateKey
-        ): void {
+        function setPrivateKey(newPrivateKey: Ed25519PrivateKey): void {
             state.privateKey = newPrivateKey;
             state.publicKey = newPrivateKey.publicKey;
             state.modalEnterAccountIdState.publicKey = newPrivateKey.publicKey;
@@ -203,38 +208,34 @@ export default createComponent({
             context.root.$router.push({ name: "interface" });
         }
 
-        async function constructOperator(
-            account: Id
-        ): Promise<import("@hashgraph/sdk").Operator> {
+        async function constructOperator(account: Id): Promise<Operator> {
             if (state.wallet !== null) {
                 if (state.wallet.hasPrivateKey()) {
                     return {
                         account,
                         privateKey: await state.wallet!.getPrivateKey()
-                    } as import("@hashgraph/sdk").Operator;
+                    } as Operator;
                 } else {
                     return {
                         account,
-                        publicKey: (await state.wallet!.getPublicKey()) as import("@hashgraph/sdk").Ed25519PublicKey,
+                        publicKey: (await state.wallet!.getPublicKey()) as Ed25519PublicKey,
                         signer: state.wallet!.signTransaction.bind(
                             state.wallet!
-                        ) as import("@hashgraph/sdk").Signer
+                        ) as Signer
                     };
                 }
             }
 
             return {
                 account: null as Id | null,
-                privateKey: null as
-                    | import("@hashgraph/sdk").Ed25519PrivateKey
-                    | null
-            } as import("@hashgraph/sdk").Operator;
+                privateKey: null as Ed25519PrivateKey | null
+            } as Operator;
         }
 
         async function constructClient(
             account: Id
-        ): Promise<import("@hashgraph/sdk").Client | undefined> {
-            let client: import("@hashgraph/sdk").Client | undefined = undefined;
+        ): Promise<Client | undefined> {
+            let client: Client | undefined = undefined;
 
             const {
                 Client,
@@ -246,9 +247,7 @@ export default createComponent({
             >);
 
             try {
-                const operator: import("@hashgraph/sdk").Operator = await constructOperator(
-                    account
-                );
+                const operator: Operator = await constructOperator(account);
 
                 client = new Client({
                     nodes: {
@@ -290,9 +289,7 @@ export default createComponent({
         }
 
         async function login(account: Id): Promise<void> {
-            const client:
-                | import("@hashgraph/sdk").Client
-                | undefined = await constructClient(account);
+            const client: Client | undefined = await constructClient(account);
 
             if (state.wallet !== null && client !== undefined) {
                 await store.dispatch(LOG_IN, {
@@ -344,7 +341,7 @@ export default createComponent({
                     state.modalAccessByHardwareState.isBusy = true;
                     try {
                         state.wallet = new LedgerNanoS();
-                        state.publicKey = (await state.wallet.getPublicKey()) as import("@hashgraph/sdk").Ed25519PublicKey;
+                        state.publicKey = (await state.wallet.getPublicKey()) as Ed25519PublicKey;
                         state.modalEnterAccountIdState.publicKey =
                             state.publicKey;
                         state.modalAccessByHardwareState.isOpen = false;
@@ -467,8 +464,8 @@ export default createComponent({
                 if (state.privateKey !== null) {
                     state.wallet = new SoftwareWallet(
                         state.loginMethod,
-                        state.privateKey as import("@hashgraph/sdk").Ed25519PrivateKey,
-                        state.publicKey as import("@hashgraph/sdk").Ed25519PublicKey
+                        state.privateKey as Ed25519PrivateKey,
+                        state.publicKey as Ed25519PublicKey
                     );
                 }
             }

--- a/src/views/CreateAccount.vue
+++ b/src/views/CreateAccount.vue
@@ -90,6 +90,13 @@ import SoftwareWallet from "../wallets/software/SoftwareWallet";
 import settings from "../settings";
 import { HederaErrorTuple, LedgerErrorTuple } from "../store/modules/errors";
 import { LoginMethod } from "../wallets/Wallet";
+import {
+    Client,
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+    Operator,
+    Signer
+} from "@hashgraph/sdk";
 
 interface State {
     loginMethod: LoginMethod | null;
@@ -164,9 +171,7 @@ export default createComponent({
 
         const keyStoreLink = ref<HTMLAnchorElement | null>(null);
 
-        function setPrivateKey(
-            newPrivateKey: import("@hashgraph/sdk").Ed25519PrivateKey
-        ): void {
+        function setPrivateKey(newPrivateKey: Ed25519PrivateKey): void {
             state.privateKey = newPrivateKey;
             state.publicKey = newPrivateKey.publicKey;
             state.modalEnterAccountIdState.publicKey = newPrivateKey.publicKey;
@@ -176,38 +181,34 @@ export default createComponent({
             context.root.$router.push({ name: "interface" });
         }
 
-        async function constructOperator(
-            account: Id
-        ): Promise<import("@hashgraph/sdk").Operator> {
+        async function constructOperator(account: Id): Promise<Operator> {
             if (state.wallet !== null) {
                 if (state.wallet.hasPrivateKey()) {
                     return {
                         account,
                         privateKey: await state.wallet!.getPrivateKey()
-                    } as import("@hashgraph/sdk").Operator;
+                    } as Operator;
                 } else {
                     return {
                         account,
-                        publicKey: (await state.wallet!.getPublicKey()) as import("@hashgraph/sdk").Ed25519PublicKey,
+                        publicKey: (await state.wallet!.getPublicKey()) as Ed25519PublicKey,
                         signer: state.wallet!.signTransaction.bind(
                             state.wallet!
-                        ) as import("@hashgraph/sdk").Signer
+                        ) as Signer
                     };
                 }
             }
 
             return {
                 account: null as Id | null,
-                privateKey: null as
-                    | import("@hashgraph/sdk").Ed25519PrivateKey
-                    | null
-            } as import("@hashgraph/sdk").Operator;
+                privateKey: null as Ed25519PrivateKey | null
+            } as Operator;
         }
 
         async function constructClient(
             account: Id
-        ): Promise<import("@hashgraph/sdk").Client | undefined> {
-            let client: import("@hashgraph/sdk").Client | undefined = undefined;
+        ): Promise<Client | undefined> {
+            let client: Client | undefined = undefined;
 
             const {
                 Client,
@@ -219,9 +220,7 @@ export default createComponent({
             >);
 
             try {
-                const operator: import("@hashgraph/sdk").Operator = await constructOperator(
-                    account
-                );
+                const operator: Operator = await constructOperator(account);
 
                 client = new Client({
                     nodes: {
@@ -255,9 +254,7 @@ export default createComponent({
         }
 
         async function login(account: Id): Promise<void> {
-            const client:
-                | import("@hashgraph/sdk").Client
-                | undefined = await constructClient(account);
+            const client: Client | undefined = await constructClient(account);
 
             if (state.wallet !== null && client !== undefined) {
                 await store.dispatch(LOG_IN, {
@@ -301,7 +298,7 @@ export default createComponent({
                     try {
                         state.modalCreateByHardwareState.isBusy = true;
                         state.wallet = new LedgerNanoS();
-                        state.publicKey = (await state.wallet.getPublicKey()) as import("@hashgraph/sdk").Ed25519PublicKey;
+                        state.publicKey = (await state.wallet.getPublicKey()) as Ed25519PublicKey;
                         state.modalEnterAccountIdState.publicKey =
                             state.publicKey;
                         state.modalCreateByHardwareState.isOpen = false;
@@ -393,7 +390,7 @@ export default createComponent({
         }
 
         function handleCreateByPhraseSubmit(
-            newPrivateKey: import("@hashgraph/sdk").Ed25519PrivateKey
+            newPrivateKey: Ed25519PrivateKey
         ): void {
             state.modalCreateByPhraseState.isOpen = false;
 
@@ -418,8 +415,8 @@ export default createComponent({
                 if (state.privateKey !== null) {
                     state.wallet = new SoftwareWallet(
                         state.loginMethod,
-                        state.privateKey as import("@hashgraph/sdk").Ed25519PrivateKey,
-                        state.publicKey as import("@hashgraph/sdk").Ed25519PublicKey
+                        state.privateKey as Ed25519PrivateKey,
+                        state.publicKey as Ed25519PublicKey
                     );
                 }
             }

--- a/src/views/InterfaceSendTransfer.vue
+++ b/src/views/InterfaceSendTransfer.vue
@@ -94,6 +94,7 @@ import ModalSuccess, {
 } from "../components/ModalSuccess.vue";
 import { Vue } from "vue/types/vue";
 import { LoginMethod } from "../wallets/Wallet";
+import { AccountId } from "@hashgraph/sdk";
 
 // Shim for IDInput ref
 type IdInput = Vue & {
@@ -281,8 +282,7 @@ export default createComponent({
                     );
                 }
 
-                const recipient: import("@hashgraph/sdk").AccountId | null =
-                    state.account;
+                const recipient: AccountId | null = state.account;
 
                 const sendAmountTinybar = new BigNumber(
                     state.amount

--- a/src/views/InterfaceUploadFile.vue
+++ b/src/views/InterfaceUploadFile.vue
@@ -73,6 +73,7 @@ import store from "../store";
 import { ALERT } from "../store/actions";
 import { REFRESH_BALANCE_AND_RATE } from "../store/actions";
 import { writeToClipboard } from "../clipboard";
+import { Ed25519PublicKey } from "@hashgraph/sdk";
 
 type AccountId = {
     shard: number;
@@ -280,7 +281,7 @@ export default createComponent({
             state.isBusy = true;
 
             const receipt = ref<TransactionReceipt | null>(null);
-            const publicKey = (await store.state.wallet.session.wallet.getPublicKey()) as import("@hashgraph/sdk").Ed25519PublicKey;
+            const publicKey = (await store.state.wallet.session.wallet.getPublicKey()) as Ed25519PublicKey;
 
             if (!publicKey) {
                 throw new Error(
@@ -290,7 +291,7 @@ export default createComponent({
                 );
             }
 
-            let fileId: import("@hashgraph/sdk").FileId | undefined = undefined;
+            let fileId: FileId | undefined = undefined;
 
             state.uploadProgress.inProgress = true;
             try {

--- a/src/wallets/Wallet.ts
+++ b/src/wallets/Wallet.ts
@@ -1,7 +1,9 @@
+import {Ed25519PrivateKey, PublicKey} from "@hashgraph/sdk";
+
 export default interface Wallet {
     hasPrivateKey(): boolean;
-    getPrivateKey(): Promise<import("@hashgraph/sdk").Ed25519PrivateKey>;
-    getPublicKey(): Promise<import("@hashgraph/sdk").PublicKey | null>;
+    getPrivateKey(): Promise<Ed25519PrivateKey>;
+    getPublicKey(): Promise<PublicKey | null>;
     getLoginMethod(): LoginMethod;
     signTransaction(arg0: Buffer | Uint8Array): Promise<Uint8Array | null>;
 }

--- a/src/wallets/hardware/LedgerNanoS.ts
+++ b/src/wallets/hardware/LedgerNanoS.ts
@@ -1,6 +1,7 @@
 import Wallet, { LoginMethod } from "../Wallet";
 import "regenerator-runtime"; // https://github.com/LedgerHQ/ledgerjs/issues/332
 import TransportWebUSB from "@ledgerhq/hw-transport-webusb";
+import {Ed25519PrivateKey, Ed25519PublicKey, PublicKey} from "@hashgraph/sdk";
 
 // Preserving, in case we need this later
 // export const LEDGER_HEDERA_PATH = "44'/3030'/0'/0'/0'";
@@ -19,7 +20,7 @@ const P1_LAST = 0x08;
 
 export type LedgerDeviceStatus = {
     deviceStatus: number;
-    publicKey?: import("@hashgraph/sdk").PublicKey | null;
+    publicKey?: PublicKey | null;
     deviceId?: string;
 };
 
@@ -32,20 +33,20 @@ interface APDU {
 }
 
 export default class LedgerNanoS implements Wallet {
-    private publicKey: import("@hashgraph/sdk").Ed25519PublicKey | null = null;
+    private publicKey: Ed25519PublicKey | null = null;
 
     public hasPrivateKey(): boolean {
         return false;
     }
 
     public async getPrivateKey(): Promise<
-        import("@hashgraph/sdk").Ed25519PrivateKey
+        Ed25519PrivateKey
     > {
         throw new Error("Cannot get private key from ledger wallet");
     }
 
     public async getPublicKey(): Promise<
-        import("@hashgraph/sdk").PublicKey | null
+        PublicKey | null
     > {
         if (this.publicKey === null) {
             const buffer = Buffer.alloc(4);

--- a/src/wallets/software/SoftwareWallet.ts
+++ b/src/wallets/software/SoftwareWallet.ts
@@ -1,15 +1,16 @@
 import Wallet, { LoginMethod } from "../Wallet";
+import {Ed25519PrivateKey, PublicKey} from "@hashgraph/sdk";
 
 export default class SoftwareWallet implements Wallet {
-    private readonly privateKey: import("@hashgraph/sdk").Ed25519PrivateKey;
-    private readonly publicKey: import("@hashgraph/sdk").PublicKey;
+    private readonly privateKey: Ed25519PrivateKey;
+    private readonly publicKey: PublicKey;
 
     private readonly loginMethod: LoginMethod;
 
     public constructor(
         loginMethod: LoginMethod,
-        privateKey: import("@hashgraph/sdk").Ed25519PrivateKey,
-        publicKey?: import("@hashgraph/sdk").PublicKey
+        privateKey: Ed25519PrivateKey,
+        publicKey?: PublicKey
     ) {
         this.privateKey = privateKey;
         this.publicKey =
@@ -26,13 +27,13 @@ export default class SoftwareWallet implements Wallet {
     }
 
     public async getPrivateKey(): Promise<
-        import("@hashgraph/sdk").Ed25519PrivateKey
+        Ed25519PrivateKey
     > {
         return this.privateKey;
     }
 
     public async getPublicKey(): Promise<
-        import("@hashgraph/sdk").PublicKey | null
+        PublicKey | null
     > {
         return this.publicKey;
     }


### PR DESCRIPTION
vaguely related to #222 

since the SDK provides Typedefs now, the `import(...).footype` syntax is no longer needed