### PR TITLE
dynamically load the hardware wallet module

### DIFF
--- a/src/views/AccessMyAccount.vue
+++ b/src/views/AccessMyAccount.vue
@@ -84,7 +84,7 @@ import {
     ref,
     SetupContext
 } from "@vue/composition-api";
-import LedgerNanoS from "../wallets/hardware/LedgerNanoS";
+
 import store from "../store";
 import {
     ALERT,
@@ -340,6 +340,12 @@ export default createComponent({
                     state.loginMethod = LoginMethod.LedgerNanoS;
                     state.modalAccessByHardwareState.isBusy = true;
                     try {
+                        const { LedgerNanoS } = await (import(
+                            "../wallets/hardware/LedgerNanoS" /* webpackChunkName: "hardware" */
+                        ) as Promise<
+                            typeof import("../wallets/hardware/LedgerNanoS")
+                        >);
+
                         state.wallet = new LedgerNanoS();
                         state.publicKey = (await state.wallet.getPublicKey()) as Ed25519PublicKey;
                         state.modalEnterAccountIdState.publicKey =

--- a/src/views/CreateAccount.vue
+++ b/src/views/CreateAccount.vue
@@ -78,7 +78,6 @@ import { CreateAccountDTO, Id } from "../store/modules/wallet";
 import ModalCreateBySoftware, {
     CreateSoftwareOption
 } from "../components/ModalCreateBySoftware.vue";
-import LedgerNanoS from "../wallets/hardware/LedgerNanoS";
 import store from "../store";
 import {
     ALERT,
@@ -296,6 +295,12 @@ export default createComponent({
                 case AccessHardwareOption.Ledger:
                     state.loginMethod = LoginMethod.LedgerNanoS;
                     try {
+                        const { LedgerNanoS } = await (import(
+                            "../wallets/hardware/LedgerNanoS" /* webpackChunkName: "hardware" */
+                        ) as Promise<
+                            typeof import("../wallets/hardware/LedgerNanoS")
+                        >);
+
                         state.modalCreateByHardwareState.isBusy = true;
                         state.wallet = new LedgerNanoS();
                         state.publicKey = (await state.wallet.getPublicKey()) as Ed25519PublicKey;

--- a/src/wallets/hardware/LedgerNanoS.ts
+++ b/src/wallets/hardware/LedgerNanoS.ts
@@ -139,3 +139,5 @@ export default class LedgerNanoS implements Wallet {
         }
     }
 }
+
+export { LedgerNanoS }


### PR DESCRIPTION
```
entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  app (452 KiB)
      css/chunk-vendors.19bb3180.css
      js/chunk-vendors.3c7e5e02.js
      css/app.e1ace026.css
      js/app.f807594d.js


  File                                   Size              Gzipped

  dist/js/chunk-63b65c7c.70610023.js     1188.35 KiB       285.48 KiB
  dist/js/chunk-0528233a.f796a18c.js     799.85 KiB        388.80 KiB
  dist/js/chunk-427ff4c1.0d9b18aa.js     482.06 KiB        136.47 KiB
  dist/js/chunk-vendors.3c7e5e02.js      262.88 KiB        89.34 KiB
  dist/js/interface.2608f4d6.js          207.07 KiB        61.47 KiB
  dist/js/app.f807594d.js                137.99 KiB        52.31 KiB
  dist/js/hardware.5fe513b4.js           18.47 KiB         6.18 KiB
  dist/js/privacy.ca1066eb.js            5.91 KiB          1.03 KiB
  dist/js/units.df4cfb74.js              5.81 KiB          1.88 KiB
  dist/js/terms.059415c5.js              5.25 KiB          1.21 KiB
  dist/js/affiliates.c224c503.js         2.61 KiB          0.97 KiB
  dist/js/chunk-2d0cf521.4d3a2c41.js     0.43 KiB          0.27 KiB
  dist/css/app.e1ace026.css              46.36 KiB         11.98 KiB
  dist/css/interface.c412e084.css        35.62 KiB         6.17 KiB
  dist/css/units.ae451203.css            7.79 KiB          4.07 KiB
  dist/css/chunk-vendors.19bb3180.css    5.06 KiB          0.71 KiB
  dist/css/privacy.ca092696.css          4.73 KiB          3.18 KiB
  dist/css/terms.b34fa2d3.css            4.51 KiB          3.12 KiB
  dist/css/affiliates.04b0e134.css       2.18 KiB          0.65 KiB

  Images and other types of assets omitted.
```
part of #222 