### PR TITLE
disables the asset budget error when building for development

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -13,7 +13,8 @@ module.exports = {
     configureWebpack: {
         target: "web",
         performance: {
-            hints: "error",
+            // only report this as an error when building for production
+            hints: process.env.NODE_ENV === "production" ? "error" : false,
             maxEntrypointSize: 512000,
             maxAssetSize: 1280000
         },


### PR DESCRIPTION
This disables the asset size limitations when doing a non-production build. The assets are bundled differently when using `yarn serve`, which would result in the checks to fail and stop the build. 

Setting hints to `warning` mode would be useless to us as developers since the assets are bundled differently than in production so I disabled the hints altogether in non-production builds.

relates to #222 

Signed-off-by: questofiranon <josh@launchbadge.com>