### PR TITLE
Fixes Scrolling lock on customer service modal

### DIFF
--- a/src/components/CustomerSupportLink.vue
+++ b/src/components/CustomerSupportLink.vue
@@ -5,10 +5,7 @@
                 $t("customerSupport.customerSupport")
             }}
         </div>
-        <ModalCustomerService
-            v-if="state.modalCustomerServiceIsOpen"
-            v-model="state.modalCustomerServiceIsOpen"
-        />
+        <ModalCustomerService v-model="state.modalCustomerServiceIsOpen" />
     </div>
 </template>
 


### PR DESCRIPTION
Removes a redundant `v-if` that was blocking the `modal-is-open` toggle set on the base `Modal` component