### PR TITLE
Removed the switches from Send.vue page and subsequent components 

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -287,6 +287,7 @@
     "Software.description": "A software wallet is a computer program designed device to secure your cryptocurrency while allowing only you to access it.",
     "Hardware.title": "Hardware",
     "Hardware.description": "A hardware wallet is a special type of wallet which stores the user's private keys in a secure hardware device.",
+    "OptionalMaxFee.maxFee": "The maximum fee for this transaction.",
     "OptionalMemo.aboutMemo": "Optionally add up to 100 characters. Memos can be useful for reference information and some exchanges require them for deposits.",
     "OptionalMemo.addMemo": "Add Memo",
     "InterfaceConvertUnits": "Convert Units",

--- a/src/components/base/TextInput.vue
+++ b/src/components/base/TextInput.vue
@@ -48,7 +48,7 @@
     >
     <div
       v-if="charCounter"
-      class="absolute -top-4 right-1"
+      class="absolute -top-3 right-8"
     >
       <div class="text-xs text-argent">
         {{ numberOfChars }}/{{ maxLength }}

--- a/src/components/interface/OptionalHbarInput.vue
+++ b/src/components/interface/OptionalHbarInput.vue
@@ -1,31 +1,23 @@
 <template>
   <div>
-    <Switch
-      v-model="isOpen"
-      label="Max Transaction Fee"
-    />
-
     <HbarInput
       v-model="value"
       medium-font
-      :disabled="!isOpen"
-      class="mt-3"
-      @update:model-value="handleUpdate"
+      class="mt-3 px-5"
     />
+    <div class="mt-2 text-sm italic text-squant px-5">
+      {{ $t("OptionalMaxFee.maxFee") }}
+    </div>
   </div>
 </template>
-
 <script lang="ts">
 import type { Hbar } from "@hashgraph/sdk";
 import { defineComponent, PropType, ref, watch } from "vue";
 
-import Switch from "../base/Switch.vue";
 import HbarInput from "../base/HbarInput.vue";
-
 export default defineComponent({
   name: "OptionalHbarInput",
   components: {
-    Switch,
     HbarInput,
   },
   props: {
@@ -36,24 +28,16 @@ export default defineComponent({
   setup(props, { emit }) {
     const isOpen = ref(false);
     const value = ref(props.defaultValue);
-
     function resetHbar() {
       value.value = props.defaultValue;
       emit("update:modelValue", value.value);
     }
-
-    function handleUpdate(fee: Hbar): void {
-      value.value = fee;
-      emit("update:modelValue", fee);
-    }
-
     watch(isOpen, () => {
       if (!isOpen.value) {
         resetHbar();
       }
     });
-
-    return { isOpen, value, handleUpdate };
+    return { isOpen, value };
   },
 });
 </script>

--- a/src/components/interface/OptionalMemo.vue
+++ b/src/components/interface/OptionalMemo.vue
@@ -1,46 +1,27 @@
 <template>
-  <div>
-    <Switch
-      v-model="state.addMemo"
-      :label="$t('OptionalMemo.addMemo')"
-      @update:modelValue="onToggle"
-    />
-
+  <div class="md:block pt-10">
     <TextInput
       v-model="state.memo"
-      class="h-16 transition-all duration-300 w-full"
+      class="h-16 px-5 mt-1"
       multiline
       :max-length="100"
       char-counter
-      :class="{
-        'mt-1 opacity-100': state.addMemo,
-        'h-0 -mt-10 opacity-0 invisible': !state.addMemo,
-      }"
       @update:modelValue="$emit('update:modelValue', state.memo)"
     />
-
     <div
-      class="text-sm italic transition-all duration-300 w-full text-squant"
-      :class="{
-        'mt-4  ': state.addMemo,
-        ' mt-14 ': !state.addMemo,
-      }"
+      class="text-sm py-2 italic px-5 text-squant mt-2"
     >
       {{ $t("OptionalMemo.aboutMemo") }}
     </div>
   </div>
 </template>
-
 <script lang="ts">
 import { defineComponent, reactive } from "vue";
 
-import Switch from "../base/Switch.vue";
 import TextInput from "../base/TextInput.vue";
-
 export default defineComponent({
   name: "OptionalMemo",
   components: {
-    Switch,
     TextInput,
   },
   props: {
@@ -52,11 +33,9 @@ export default defineComponent({
       addMemo: false,
       memo: "",
     });
-
     function onToggle(open: boolean): void {
       if (!open) state.memo = "";
     }
-
     return { state, onToggle };
   },
 });

--- a/src/pages/interface/DownloadFile.vue
+++ b/src/pages/interface/DownloadFile.vue
@@ -1,63 +1,89 @@
 <template>
-    <Headline title="Download" parent="tools" />
+  <Headline
+    title="Download"
+    parent="tools"
+  />
 
-    <div container class="h-screen flex flex-col max-w-lg m-auto mt-10">
-        <label
-            class="font-medium text-squant dark:text-white mb-4"
-        >{{ $t("InterfaceDownload.fileId") }}</label>
-        <EntityIdInput
-            type="file"
-            v-model="state.downloadId"
-            :placeholder="$t('AccessAccount.section2.input.placeholder')"
-        />
+  <div
+    container
+    class="h-screen flex flex-col max-w-lg m-auto mt-10"
+  >
+    <label
+      class="font-medium text-squant dark:text-white mb-4"
+    >{{ $t("InterfaceDownload.fileId") }}</label>
+    <EntityIdInput
+      v-model="state.downloadId"
+      type="file"
+      :placeholder="$t('AccessAccount.section2.input.placeholder')"
+    />
 
-        <InputError v-if= "state.errorMessage.length > 0"> {{ state.errorMessage }} </InputError>
+    <InputError v-if="state.errorMessage.length > 0">
+      {{ state.errorMessage }}
+    </InputError>
 
+    <Button
+      color="green"
+      class="py-3 mt-6 w-full mt-10"
+      :busy="state.sendBusyText != null"
+      @click="openModal"
+    >
+      {{ $t("InterfaceToolTile.download.title") }}
+    </Button>
+
+    <Modal
+      :is-visible="state.showFeeModal"
+      :title="modalTitle"
+      @close="closeModal"
+    >
+      <div class="table-auto mt-8 p-4">
+        <tr>
+          <td class="w-full">
+            {{ $t('InterfaceTransactionDetails.operator') }}
+          </td>
+          <td class>
+            {{ accountId.toString() }}
+          </td>
+        </tr>
+        <tr>
+          <td class>
+            {{ $t('InterfaceTransactionDetails.estimate') }}
+          </td>
+          <td class>
+            {{ state.maxFee }}
+          </td>
+        </tr>
+      </div>
+
+      <div class="mt-4 w-full text-center">
         <Button
-            color="green"
-            class="py-3 mt-6 w-full mt-10"
-            :busy="state.sendBusyText != null"
-            @click="openModal"
-        >{{ $t("InterfaceToolTile.download.title") }}</Button>
-
-        <Modal :isVisible="state.showFeeModal" :title="modalTitle" @close="closeModal">
-            <div class="table-auto mt-8 p-4">
-                <tr>
-                    <td class="w-full">{{ $t('InterfaceTransactionDetails.operator') }}</td>
-                    <td class>{{ accountId.toString() }}</td>
-                </tr>
-                <tr>
-                    <td class>{{ $t('InterfaceTransactionDetails.estimate') }}</td>
-                    <td class>{{ state.maxFee }}</td>
-                </tr>
-            </div>
-
-            <div class="mt-4 w-full text-center">
-                <Button
-                    color="white"
-                    class="p-3 w-5/12 m-2"
-                    @click="closeModal"
-                >{{ $t('BaseButton.dismiss') }}</Button>
-                <Button
-                    color="green"
-                    class="p-3 w-5/12 m-2"
-                    @click="download"
-                >{{ $t('BaseButton.continue') }}</Button>
-            </div>
-        </Modal>
-    </div>
+          color="white"
+          class="p-3 w-5/12 m-2"
+          @click="closeModal"
+        >
+          {{ $t('BaseButton.dismiss') }}
+        </Button>
+        <Button
+          color="green"
+          class="p-3 w-5/12 m-2"
+          @click="download"
+        >
+          {{ $t('BaseButton.continue') }}
+        </Button>
+      </div>
+    </Modal>
+  </div>
 </template>
 
 
 <script lang = "ts">
 import { defineComponent, reactive, nextTick, computed } from "vue";
+
 import Headline from "../../components/interface/Headline.vue";
 import Button from "../../components/base/Button.vue";
 import Modal from "../../components/interface/Modal.vue";
 import EntityIdInput from "../../components/base/EntityIdInput.vue";
 import InputError from "../../components/base/InputError.vue";
 import { useStore } from "../../store";
-import { Hbar, HbarUnit, FileContentsQuery } from "@hashgraph/sdk";
 
 export default defineComponent({
     name: "DownloadFile",

--- a/src/pages/interface/Send.vue
+++ b/src/pages/interface/Send.vue
@@ -7,8 +7,8 @@
   <div
     class="pb-10 mt-8 font-medium border-b text-carbon border-cerebral-grey dark:border-midnight-express"
   >
-    <div class="flex flex-wrap items-center p-8">
-      <div class="w-full">
+    <div class="flex flex-wrap p-8">
+      <div class="w-1/2">
         <!-- TODO: when localizing, remove the v-if, the pluralization should be done in the localizer -->
         <div
           v-if="state.transfers.length <= 1"
@@ -25,7 +25,16 @@
         </div>
 
         <div
-          class="p-4 font-medium bg-white border rounded shadow-md dark:bg-ruined-smores border-jupiter dark:border-midnight-express"
+          class=" 
+                  p-4
+                  font-medium
+                  bg-white
+                  border
+                  rounded
+                  shadow-md
+                  dark:bg-ruined-smores
+                  border-jupiter
+                  dark:border-midnight-express"
         >
           <TransferForm
             v-model:to="state.transfer.to"
@@ -36,17 +45,7 @@
         </div>
       </div>
 
-      <div class="w-full p-4 mt-4 mb-2 md:p-0">
-        <div class="dark:text-silver-polish">
-          From
-        </div>
-
-        <TextInput
-          :model-value="state.accountId?.toString() ?? ''"
-          read-only
-          class="mt-2 font-medium rounded"
-        />
-
+      <div class="w-1/2 p-4 mt-4 mb-2 md:p-0">
         <OptionalMemo
           v-model="state.memo"
           class="mt-8"
@@ -57,10 +56,6 @@
           class="mt-8"
           :default-value="state.defaultMaxFee"
         />
-
-        <div class="mt-2 text-sm italic text-squant">
-          {{ $t("OptionalMaxFee.maxFee") }}
-        </div>
       </div>
     </div>
 

--- a/src/pages/interface/Send.vue
+++ b/src/pages/interface/Send.vue
@@ -3,7 +3,6 @@
     title="Send"
     parent="home"
   />
-
   <div
     class="pb-10 mt-8 font-medium border-b text-carbon border-cerebral-grey dark:border-midnight-express"
   >
@@ -16,16 +15,14 @@
         >
           {{ $t("InterfaceHomeSend.section1.header1") }}
         </div>
-
         <div
           v-else
           class="mb-2 dark:text-silver-polish"
         >
           {{ $t("InterfaceTransactionDetails.transfers") }}
         </div>
-
         <div
-          class=" 
+          class="
                   p-4
                   font-medium
                   bg-white
@@ -44,13 +41,11 @@
           />
         </div>
       </div>
-
       <div class="w-1/2 p-4 mt-4 mb-2 md:p-0">
         <OptionalMemo
           v-model="state.memo"
           class="mt-8"
         />
-
         <OptionalHbarInput
           v-model="state.maxFee"
           class="mt-8"
@@ -58,7 +53,6 @@
         />
       </div>
     </div>
-
     <!-- TODO: Enable Multiple Asset Transfers -->
     <!-- <Button
       color="white"
@@ -68,7 +62,6 @@
       {{ $t("BaseButton.addTransfer1") }}
     </Button> -->
   </div>
-
   <div
     v-if="state.generalErrorText != null"
     class="px-4 py-3 mx-auto mt-10 -mb-8 rounded bg-unburdened-pink w-max"
@@ -77,7 +70,6 @@
       {{ state.generalErrorText }}
     </div>
   </div>
-
   <!-- bottom buttons section -->
   <div class="flex flex-col items-center w-7/12 m-auto mt-10 mb-10">
     <Button
@@ -89,7 +81,6 @@
     >
       {{ state.sendBusyText ?? "Send" }}
     </Button>
-
     <Button
       color="white"
       class="py-2 mt-4 text-sm px-9"
@@ -99,14 +90,13 @@
     </Button>
   </div>
 </template>
-
 <script lang="ts">
 import {
     computed,
-    defineComponent, 
-    onMounted, 
-    reactive, 
-    ref 
+    defineComponent,
+    onMounted,
+    reactive,
+    ref
 } from "vue";
 import { BigNumber } from "bignumber.js";
 import type { AccountId } from "@hashgraph/sdk";
@@ -119,14 +109,12 @@ import OptionalMemo from "../../components/interface/OptionalMemo.vue";
 import Button from "../../components/base/Button.vue";
 import TextInput from "../../components/base/TextInput.vue";
 import { useStore } from "../../store";
-
 export interface Transfer {
     to?: AccountId;
     asset: string; // "HBAR" or token ID (string)
     amount?: BigNumber;
     usd?: string;
 }
-
 export default defineComponent({
   name: "Send",
   components: {
@@ -141,11 +129,9 @@ export default defineComponent({
     const router = useRouter();
     const store = useStore();
     const hashgraph = ref<typeof import("@hashgraph/sdk") | null>(null);
-
     onMounted(async () => {
         hashgraph.value = await import("@hashgraph/sdk");
     });
-    
     let state = reactive({
       accountId: store.accountId,
       showAddModal: false,
@@ -164,17 +150,13 @@ export default defineComponent({
       } as Transfer,
       transfers: [] as Transfer[],
     });
-
     const sendValid = computed(
       () => state.transfer.to != null && state.transfer.amount != null
     );
-
     async function onSend(): Promise<void> {
        if (store.client == null) return;
-      
       state.sendBusyText = "Executing transaction …";
       state.generalErrorText = null;
-
       try {
         await store.client.transfer({
           transfers: [state.transfer],
@@ -184,9 +166,7 @@ export default defineComponent({
             state.sendBusyText = "Waiting for confirmation …";
           },
         });
-
         void store.requestAccountBalance();
-
         // go back to home
         // goal is to see the now PENDING transaction
         // so we can watch it "reach consensus"
@@ -197,15 +177,12 @@ export default defineComponent({
         state.sendBusyText = null;
       }
     }
-
     function removeTransfer(index: number) {
       state.transfers.splice(index, 1);
     }
-
     function onCancel() {
       router.back();
     }
-
     return {
       state,
       sendValid,

--- a/src/pages/interface/Tools.vue
+++ b/src/pages/interface/Tools.vue
@@ -8,11 +8,11 @@
       :to="{ name: 'tools.associate.token' }"
     />
 
-    <ToolTile
+    <!-- <ToolTile
       :title="$t('InterfaceToolTile.download.title')"
       :description="$t('InterfaceToolTile.download.description')"
       :to="{ name: 'tools.download' }"
-    />
+    /> -->
 
     <!-- <ToolTile
       :title="$t('InterfaceConvertUnits')"


### PR DESCRIPTION
**Description**:
*This pull requests edits the styling of the send hbar page and removes the built in switches. 
*This was done because of a jarring transition created when the switch was pressed to toggle collapse.
*An item would be removed from the dom post transition by the Vue transition block causing text to leap upward

This PR modifies ... in order to support ...
* Locales -> MaxHbar fee input hint
* Send.vue -> repairing column styling for side by side and switch removal 
* OptionalHbarInput.vue -> removed switch
*OptionalMemo.vue -> removed switch 


**Related issue(s)**:
N/A

Fixes #
N/A

**Notes for reviewer**:
N/A

**Checklist**

- N/A Documented 
- [x] Tested (unit)
