### PR TITLE
refactor: update kabuto transaction history link to v2

### DIFF
--- a/src/components/interface/KabutoLink.vue
+++ b/src/components/interface/KabutoLink.vue
@@ -73,8 +73,12 @@ export default defineComponent({
     },
     setup(){
         const store = useStore();
+
         function goToKabuto(): void {
-            window.open(`https://explorer.kabuto.sh/mainnet/id/${store.accountId?.toString()}`);
+            const accountId = store.accountId?.toString();
+            const network = store.network;
+
+            window.open(`https://v2.explorer.kabuto.sh/id/${accountId}?network=${network}`);
         }
 
         return {


### PR DESCRIPTION
Signed-off-by: Jack Ta <jack.th.ta@gmail.com>

### Description:
- The redirect link for this component points to the old v1 Kabuto explorer. This PR will update it to point to the new v2 Kabuto explorer.
<img width="400" alt="Screen Shot 2021-11-29 at 4 01 17 PM" src="https://user-images.githubusercontent.com/22848332/144315405-ab86163c-1dac-42ff-b149-fb368af4359f.png">
