### PR TITLE
refactor: modify bouncing reload prompt for better UX

### DIFF
--- a/src/components/base/ReloadPrompt.vue
+++ b/src/components/base/ReloadPrompt.vue
@@ -1,27 +1,27 @@
 <template>
   <transition
-    leave-active-class="duration-500 ease"
-    leave-from-class="translate-x-0 opacity-100"
-    leave-to-class="translate-x-full opacity-0"
-    enter-active-class="duration-500 ease"
     enter-from-class="translate-x-full opacity-0"
+    enter-active-class="duration-500 ease-out"
     enter-to-class="translate-x-0 opacity-100"
+    leave-from-class="translate-x-0 opacity-100"
+    leave-active-class="duration-300 ease-in"
+    leave-to-class="translate-x-full opacity-0"
   >
     <div
       v-if="offlineReady || needRefresh"
       role="alert"
-      class="p-6 pt-8 animate-bounce rounded flex flex-col fixed z-50 items-center justify-center h-40 p-4 overflow-hidden italic rounded shadow-lg bottom-10 right-10 w-200 bg-snow-ballet dark:border dark:bg-dreamless-sleep dark:border-midnight-express dark:text-white"
+      class="p-6 pt-8 animate-pulse rounded flex flex-col fixed z-50 items-center justify-center h-40 p-4 overflow-hidden italic rounded shadow-lg bottom-10 right-10 w-200 bg-snow-ballet dark:border dark:bg-dreamless-sleep dark:border-midnight-express dark:text-white"
     >
       <span
         v-if="offlineReady"
         class="mr-4 ml-4"
       >{{ $t("Common.SW.OfflineReady") }}</span>
-    
+
       <span
         v-else
         class="mr-4 ml-4"
       >{{ $t("Common.SW.NewContentAvailable") }}</span>
-    
+
       <div class="mt-6 space-x-4 justify-between text-center w-full">
         <Button
           class="py-2 w-2/5 m-auto mb-4"
@@ -69,8 +69,6 @@ export default defineComponent({
             offlineReady.value = false;
             needRefresh.value = false;
         }
-
-        
 
         return {
             offlineReady,


### PR DESCRIPTION
Signed-off-by: Jack Ta <jack.th.ta@gmail.com>

**Description**:
- The bouncing reload prompt impedes on user experience as it makes it difficult to press the **Reload** button as it bounces infinitely.

**Notes**:
- Upon working on this PR, I noticed that Vue's enter/leave transitions (e.g. `enter|leave-from-class`, `enter|leave-active-class`, `enter|leave-to-class`) were not being triggered alongside the use of `animate-bounce`. The enter/leave transitions are supposed to have the reload prompt slide in/out horizontally when new content is detected and if the **Close** button is pressed, respectively. You can see this missing in the first video below titled _animate-bounce.mov_ and in its working state in the second video below titled _animate-pulse.mov_

https://user-images.githubusercontent.com/22848332/145099321-4c0ced0a-c5d6-42e3-8fab-806b935826ff.mov

- To remedy both the issue mentioned in the description alongside the bug mentioned in the notes, I used `animate-pulse` instead of `animate-bounce` because it ...
1.  ... makes it easier to click the **Reload** button 
2. ... works alongside the enter/leave transitions

https://user-images.githubusercontent.com/22848332/145099860-e6a10d6f-9a96-4668-be95-0fbf3d9daeec.mov

- I have tried limiting the iteration of bounces the prompt can make, but the animation isn't fluid in returning back to a resting state after its last bounce iteration (see below)

https://user-images.githubusercontent.com/22848332/145101213-82691e2c-1610-428a-92a4-c8dac8c3abd2.mov