### PR TITLE
refactor: distinguish ledger deny request err msg from general err msg

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -78,6 +78,7 @@
     "Common.Error.EmptyTransaction": "This transaction contains no transfers, and is invalid.",
     "Common.Error.FileDeleted": "The requested file has been deleted.",
     "Common.Error.LedgerError": "There was a problem while communicating with your ledger. Please reset and try again.",
+    "Common.Error.LedgerDenyRequest": "Denied request on ledger.",
     "Common.Error.MemoTooLong": "The provided memo is too long.",
     "Common.Error.NetworkUnavailable": "The network is currently unavailable. Try again later.",
     "Common.Error.NoFileId": "No File ID for the Uploaded File. Something went wrong.",

--- a/src/pages/access/Account.vue
+++ b/src/pages/access/Account.vue
@@ -117,7 +117,7 @@
       </div>
       <div class="h-0 border-b w-52 border-cerebral-grey" />
     </div>
-    
+
     <CustomerSupportButton class="text-center text-mountain-meadow" />
   </Layout>
 </template>
@@ -149,6 +149,7 @@ interface State {
   accountId: AccountId | null;
   error: boolean;
   errorMessage: string;
+  caughtError: Error;
   busy: boolean;
   busyMessage: string;
 }
@@ -176,6 +177,7 @@ export default defineComponent({
       accountId: null,
       error: false,
       errorMessage: "",
+      caughtError: null,
       busy: false,
       busyMessage: ""
     });
@@ -246,6 +248,7 @@ export default defineComponent({
       state.busyMessage = "Verifying account …";
       state.error = false;
       state.errorMessage = "";
+      state.caughtError = null;
 
       try {
         let client;
@@ -264,7 +267,7 @@ export default defineComponent({
                 network: store.network,
               });
             } catch (error) {
-              console.warn(error);
+              state.caughtError = error;
             }
 
             if (client != null) break;
@@ -272,7 +275,14 @@ export default defineComponent({
 
           if (client == null) {
             state.error = true;
-            state.errorMessage = i18n.t("Common.Error.AccountKeyMismatch").toString()
+
+            if (state.caughtError) {
+                state.errorMessage = await store.errorMessage(state.caughtError);
+            } else {
+                // Account key mismatch does not throw an error
+                state.errorMessage = i18n.t("Common.Error.AccountKeyMismatch").toString()
+            }
+
             return;
           }
 


### PR DESCRIPTION
Signed-off-by: Jack Ta <jack.th.ta@gmail.com>

**Description**:
- When denying a request on a ledger device, the error message that displays thereafter on MHW does not accurately represent that action.
  - e.g.: 
    - _None of the attempted key pairs are associated with this account._ when accessing ledger w/ incorrect account id
    - _There was a problem while communicating with your ledger. Please reset and try again._ when denying a send request.
- This PR fixes that and will show a _Denied request on ledger._ message on MHW after denying a request on the ledger.