### PR TITLE
fix: update CSP and fix kabuto api call for mainnet

### DIFF
--- a/src/components/interface/Transactions.vue
+++ b/src/components/interface/Transactions.vue
@@ -149,10 +149,10 @@ interface Transfer {
 
 export default defineComponent({
   name: "Transactions",
-  components: { 
-    Hint, 
-    KabutoLink, 
-    Transaction 
+  components: {
+    Hint,
+    KabutoLink,
+    Transaction
   },
   props: {
     hideHeader: { type: Boolean, default: false },
@@ -164,7 +164,7 @@ export default defineComponent({
     const accountId = computed(() => store.accountId);
 
     function isSender(txr: CryptoTransfer): boolean {
-      return txr.id.toString().split("@")[0] === accountId.value?.toString(); 
+      return txr.id.toString().split("@")[0] === accountId.value?.toString();
     }
     const filtered = computed(() => {
       if (props.filter === "all") return state.latestTransactions;
@@ -197,7 +197,6 @@ export default defineComponent({
     });
 
     onMounted(async () => {
-      // TODO: Fix API call when Kabuto V2 is operational
       try {
         state.latestTransactions = await getLatestTransactions() ?? [] as CryptoTransfer[];
         const len = filtered.value.length;

--- a/src/services/impl/hedera/client/get-account-records.ts
+++ b/src/services/impl/hedera/client/get-account-records.ts
@@ -5,13 +5,14 @@ import { CryptoTransfer } from "../../../../domain/CryptoTransfer";
 
 export async function getAccountRecords(): Promise<CryptoTransfer[] | undefined>{
     const store = useStore();
+    const network = store.network === "mainnet" ? "" : ".testnet";
 
-    const resp = await axios.get(`https://v2.api.${store.network}.kabuto.sh/transaction?filter[entityId]=${store.accountId}`)
+    const resp = await axios.get(`https://v2.api${network}.kabuto.sh/transaction?filter[entityId]=${store.accountId}`)
         .then(({ data }) => data)
-        .catch((error: Error)=>{
+        .catch((error: Error) => {
             throw error;
         });
-    
+
     //Display items from newest to oldest (Kabuto started showing oldest first)
     return resp.data.reverse() as CryptoTransfer[];
 }

--- a/src/services/impl/hedera/client/get-transaction.ts
+++ b/src/services/impl/hedera/client/get-transaction.ts
@@ -5,11 +5,10 @@ import { CryptoTransfer } from "../../../../domain/CryptoTransfer";
 
 export async function getTransfer(options: { hash: string } ): Promise<CryptoTransfer> {
     const store = useStore();
+    const network = store.network === "mainnet" ? "" : ".testnet";
 
-    //TODO: Replace with proper API call when API is fixed
-    //https://v2.api.${store.network}.kabuto.sh/transaction/:${options.hash}
-    const resp = await axios.get(`https://v2.api.${store.network}.kabuto.sh/transaction?filter[entityId]=${store.accountId}`)
-        .then( ({ data }) => data)
+    const resp = await axios.get(`https://v2.api${network}.kabuto.sh/transaction?filter[entityId]=${store.accountId}`)
+        .then(({ data }) => data)
         .catch((error: Error) => {
             throw error;
         });

--- a/vite.config.js
+++ b/vite.config.js
@@ -34,7 +34,8 @@ export default async function ({ mode }) {
                 "grpc-web.previewnet.myhbarwallet.com",
                 "grpc-web.myhbarwallet.com",
                 "api.coingecko.com",
-                "v2.api.testnet.kabuto.sh"
+                "v2.api.kabuto.sh",
+                "v2.api.testnet.kabuto.sh",
             ].join(" "),
         "font-src 'self' data:",
         isProduction ? "style-src 'self'" : "style-src 'self' 'unsafe-inline'",


### PR DESCRIPTION
Signed-off-by: Jack Ta <jack.th.ta@gmail.com>

**Description**:
- Content Security Policy did not include Kabuto v2's mainnet endpoint and until this PR, all calls to Kabuto v2's api only worked for testnet.

**Note**:
- Kabuto V2 **mainnet** endpoint: `v2.api.kabuto.sh`
- Kabuto V2 **testnet** endpoint: `v2.api.testnet.kabuto.sh`