### PR TITLE
fix: display recent txs from newest to oldest

### DIFF
--- a/src/services/impl/hedera/client/get-account-records.ts
+++ b/src/services/impl/hedera/client/get-account-records.ts
@@ -13,6 +13,5 @@ export async function getAccountRecords(): Promise<CryptoTransfer[] | undefined>
             throw error;
         });
 
-    //Display items from newest to oldest (Kabuto started showing oldest first)
-    return resp.data.reverse() as CryptoTransfer[];
+    return resp.data as CryptoTransfer[];
 }


### PR DESCRIPTION
**Description**:
Currently, the oldest transactions of the user are displayed first (Home, History). It seems that Kabuto has changed the order and now returns the newest transactions first. So there is no need to reverse the order in MyHbarWallet anymore.