### PR TITLE
fix: convert units tool

### DIFF
--- a/src/pages/interface/ConvertUnits.vue
+++ b/src/pages/interface/ConvertUnits.vue
@@ -194,25 +194,25 @@ export default defineComponent({
     });
 
 
-    function handleInputValueLeft(value: string): void {
+    async function handleInputValueLeft(value: string): Promise<void> {
       if (isNaN(parseInt(value))) {
         return;
       }
       state.valueLeft = value;
-      computeValueRight();
+      await computeValueRight();
     }
 
-    function handleInputValueRight(value: string): void {
+    async function handleInputValueRight(value: string): Promise<void> {
       if (isNaN(parseInt(value))) {
         return;
       }
       state.valueRight = value;
-      computeValueLeft();
+      await computeValueLeft();
     }
 
     async function handleSelect(): Promise<void> {
-      computeValueLeft();
-      computeValueRight();
+      await computeValueLeft();
+      await computeValueRight();
     }
 
     async function getHbarUnit(value: string): Promise<import("@hashgraph/sdk").HbarUnit> {

--- a/src/pages/interface/ConvertUnits.vue
+++ b/src/pages/interface/ConvertUnits.vue
@@ -196,6 +196,7 @@ export default defineComponent({
 
     async function handleInputValueLeft(value: string): Promise<void> {
       if (isNaN(parseInt(value))) {
+        state.valueRight = "";
         return;
       }
       state.valueLeft = value;
@@ -204,6 +205,7 @@ export default defineComponent({
 
     async function handleInputValueRight(value: string): Promise<void> {
       if (isNaN(parseInt(value))) {
+        state.valueLeft = "";
         return;
       }
       state.valueRight = value;
@@ -211,6 +213,9 @@ export default defineComponent({
     }
 
     async function handleSelect(): Promise<void> {
+      if (isNaN(parseInt(state.valueLeft)) || isNaN(parseInt(state.valueRight))) {
+        return;
+      }
       await computeValueLeft();
       await computeValueRight();
     }

--- a/src/pages/interface/ConvertUnits.vue
+++ b/src/pages/interface/ConvertUnits.vue
@@ -94,7 +94,7 @@
           </td>
           
           <td class="w-1/3 flex overflow-wrap">
-            {{ unit.amountInHbar }} {{ units[2].symbol }}
+            {{ unit.amountInHbar }} ℏ
           </td>
         </tr>
       </div>
@@ -137,11 +137,19 @@ export default defineComponent({
         amountInHbar: "1",
       },
       {
-        name: "Millibar",
+        name: "Microbar",
         iconLight: null,
         iconDark: null,
         symbol: "μℏ",
         amount: "1,000,000",
+        amountInHbar: "1",
+      },
+      {
+        name: "Millibar",
+        iconLight: null,
+        iconDark: null,
+        symbol: "mℏ",
+        amount: "1,000",
         amountInHbar: "1",
       },
       {


### PR DESCRIPTION
**Description**:
There were a few bugs with the tool for converting hbar units:
- In the hbar unit reference guide, data from Millibar and Microbar was mixed and one of them was missing
- The tool displayed wrong results when changing a selected unit due to incorrect promise handling (missing awaits)
- NaN inputs could produce uncaught errors (when changing a selected unit) or display confusing results (e.g. when clearing the left input element)
