### PR TITLE
fix: Create > `Mnemonic` | `MnemonicVerify` not showing mnemonic words

### DIFF
--- a/src/pages/create/Mnemonic.vue
+++ b/src/pages/create/Mnemonic.vue
@@ -10,7 +10,7 @@
     >
       <MnemonicInput
         v-if="mnemonicPhrase"
-        :model-value="mnemonicPhrase.words"
+        :model-value="[...mnemonicPhrase.toString().split(' ')]"
         :word-count="24"
         read-only
       />

--- a/src/pages/create/MnemonicVerify.vue
+++ b/src/pages/create/MnemonicVerify.vue
@@ -79,7 +79,7 @@ export default defineComponent({
 
     if (store.wallet != null) {
       try {
-        mnemonicPhrase.value = (store.wallet as MnemonicSoftwareWallet).getMnemonic().words;
+        mnemonicPhrase.value = (store.wallet as MnemonicSoftwareWallet).getMnemonic().toString().split(' ');
         password.value = (store.wallet as MnemonicSoftwareWallet).getPassword();
       } catch (error) {
         router.push({ name: "create" });


### PR DESCRIPTION
**Description**:
``` 
<MnemonicInput
    v-if="mnemonicPhrase"
    :model-value="mnemonicPhrase.words"
    :word-count="24"
    read-only
  />
```
- The `words` seem to now be wrapped inside a `_mnemonic` property, so passing `mnemonicPhrase._mnemonic.words` in for `:model-value` fixes it, but probably isn't best practice to access `_`-prefixed properties like that. Therefore went with the alternative: `[...mnemonicPhrase.toString().split(' ')]`.