### PR TITLE
fix: adds missing node host data to the mainnetNodes array

### DIFF
--- a/src/pages/interface/Staking.vue
+++ b/src/pages/interface/Staking.vue
@@ -318,6 +318,9 @@ export default defineComponent({
             { name: "DBS", location: "Singapore, Republic of Singapore" },
             { name: "ServiceNow", location: "Ogden, Utah" },
             { name: "Ubisoft", location: "Singapore, Republic of Singapore" },
+            { name: "abrdn", location: "London, UK" },
+            { name: "Dell", location: "New Jersey, USA" },
+            { name: "COFRA Holdings", location: "Germany" },
         ];
 
         function getHostInfoForNode(


### PR DESCRIPTION
**Description**:
This PR adds the following Node Host data to the mainnetNodes array:
* abrdn
* Dell
* COFRA Holdings

**Related issue(s)**:

Fixes #592 